### PR TITLE
Update Practical-04-Reuse.qmd

### DIFF
--- a/practicals/Practical-04-Reuse.qmd
+++ b/practicals/Practical-04-Reuse.qmd
@@ -329,20 +329,20 @@ Let's try this with a 'bigger' data set... In an ideal world, the 'power' of cod
 from urllib.request import urlopen
 import csv
 
-url = "https://raw.githubusercontent.com/jreades/fsds/master/data/src/Wikipedia-Cities.csv"
-response = urlopen(url)
-raw = response.read()
+Url = "https://raw.githubusercontent.com/jreades/fsds/master/data/src/Wikipedia-Cities.csv"
+response = urlopen(Url)
+Raw = response.read()
 
-csvfile = csv.reader(raw.decode('utf-8').splitlines())
+csvFile = csv.reader(Raw.decode('utf-8').splitlines())
 
-urlData = [] # Somewhere to store the data
+UrlData = [] # Somewhere to store the data
 
-for row in csvfile:              
-    urlData.append( row )
+for row in csvFile:              
+    UrlData.append( row )
 
-print(f"urlData has {len(urlData)} rows and {len(urlData[0])} columns.")
+print(f"UrlData has {len(urlData)} rows and {len(UrlData[0])} columns.")
 
-for u in urlData[70:]:  # For each row in the list
+for u in UrlData[70:]:  # For each row in the list
     print(f"The city of '{u[0]}' has a population of {u[1]}") # Print out the name and pop
 ```
 
@@ -353,7 +353,7 @@ for u in urlData[70:]:  # For each row in the list
 I have assumed that, just because the files have similar names, they must also have similar layouts!
 
 ```{python}
-print(f"The URL's data labels are: {', '.join(urlData[0])}")
+print(f"The URL's data labels are: {', '.join(UrlData[0])}")
 ```
 
 :::

--- a/practicals/Practical-04-Reuse.qmd
+++ b/practicals/Practical-04-Reuse.qmd
@@ -340,7 +340,7 @@ UrlData = [] # Somewhere to store the data
 for row in csvFile:              
     UrlData.append( row )
 
-print(f"UrlData has {len(urlData)} rows and {len(UrlData[0])} columns.")
+print(f"UrlData has {len(UrlData)} rows and {len(UrlData[0])} columns.")
 
 for u in UrlData[70:]:  # For each row in the list
     print(f"The city of '{u[0]}' has a population of {u[1]}") # Print out the name and pop

--- a/practicals/Practical-05-Objects.qmd
+++ b/practicals/Practical-05-Objects.qmd
@@ -145,7 +145,7 @@ Now let's do the standard deviation:
 import numpy as np
 # Use numpy functions to calculate mean and standard deviation
 std  = np.??(??)
-print(f"City distribution has a standard deviation of {std:,.2f}.")
+print(f"City population has a standard deviation of {std:,.2f}.")
 ```
 
 #### Answer
@@ -154,7 +154,7 @@ print(f"City distribution has a standard deviation of {std:,.2f}.")
 import numpy as np
 # Use numpy functions to calculate mean and standard deviation
 std  = np.std(myData['Population'])
-print(f"City distribution has a standard deviation of {std:,.2f}.")
+print(f"City population has a standard deviation of {std:,.2f}.")
 ```
 
 ::::


### PR DESCRIPTION
In the section "The Advantages of a Package", practical 4, lines 355-357 in the code,
it prints: **The URL's data labels are: City, Population, Latitude, Longitude.**
This is incorrect, because it mixes with the previous variables with the same name. In this example, the url is different, and the text should say: **The URL's data labels are: City, Region, Founded, Population, URL, Longitude, Latitude**

I changed slightly the variable names in this code block to avoid overlap.